### PR TITLE
Fix integer overflow by changing dtype from uint8 to uint16

### DIFF
--- a/04-numpy/sec3-vectorize/array_and_broadcasting.py
+++ b/04-numpy/sec3-vectorize/array_and_broadcasting.py
@@ -14,7 +14,7 @@ array_100000 = np.arange(100000)
 array_100000 += array_100000
 
 x = np.array([[0, 20], [250, 500], [1, 2]],
-             dtype=np.uint8)
+             dtype=np.uint16)
 y = np.array([[1, 10], [25, 5]], dtype=np.uint8)
 
 print(sum_arrays(x, y))


### PR DESCRIPTION
In `04-numpy/sec3-vectorize/array_and_broadcasting.py`, 'x' is initialized with `np.uint8`.
However, the values  [500] cannot be assigned as an element of array 'x'  as it overflows the `uint8` limit (255), resulting in 'OverflowError'.
I have changed the dtype to `np.uint16` to handle larger values correctly.